### PR TITLE
#164 - made some minor optimizations

### DIFF
--- a/src/main/java/us/com/plattrk/service/IncidentNotificationServiceImpl.java
+++ b/src/main/java/us/com/plattrk/service/IncidentNotificationServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import us.com.plattrk.api.model.EntityType;
 import us.com.plattrk.api.model.Incident;
 import us.com.plattrk.api.model.Notification;
-import us.com.plattrk.repository.IncidentRepository;
 import us.com.plattrk.repository.NotificationRepository;
 import us.com.plattrk.service.Mail.Type;
 
@@ -26,9 +25,6 @@ public class IncidentNotificationServiceImpl extends NotificationTimeFrame imple
 
     @Autowired
     private Properties appProperties;
-
-    @Autowired
-    private IncidentRepository incidentRepository;
 
     private Incident incident;
 
@@ -188,9 +184,11 @@ public class IncidentNotificationServiceImpl extends NotificationTimeFrame imple
 
     @Override
     public void sendEmail(Type type) throws SendFailedException {
+        if (this.incident == null)
+            throw new IllegalStateException("No Incident set.");
+
         toggleOnHours();
 
-        incident = incidentRepository.getIncident(incident.getId()).get();
         try {
             if (isOnHours()) {
                 mailService.send(incident, appProperties, type);


### PR DESCRIPTION
Related to #164 

 1 - WebApplicationContext wac initiation was being performed at every polling interval and this is only needed to be initiated if any open incidents exist.  

2 - sendMail method's class has already an assigned incident. It is querying the DB for the same incident again. 